### PR TITLE
Add  --ssl-no-revoke to curl example

### DIFF
--- a/docs/dev/dev-proxy/get-started.md
+++ b/docs/dev/dev-proxy/get-started.md
@@ -255,7 +255,7 @@ Invoke-WebRequest -Uri https://jsonplaceholder.typicode.com/posts
 If you use `curl`, send a GET request to the JSON Placeholder API using the following command.
 
 ```console
-curl -ix http://localhost:8000 https://jsonplaceholder.typicode.com/posts
+curl --ssl-no-revoke -ix http://localhost:8000 https://jsonplaceholder.typicode.com/posts
 ```
 
 You can also use an API client like [Postman](https://www.postman.com/product/api-client/) to send a GET request to `https://jsonplaceholder.typicode.com/posts`.

--- a/docs/dev/dev-proxy/get-started.md
+++ b/docs/dev/dev-proxy/get-started.md
@@ -255,7 +255,7 @@ Invoke-WebRequest -Uri https://jsonplaceholder.typicode.com/posts
 If you use `curl`, send a GET request to the JSON Placeholder API using the following command.
 
 ```console
-curl --ssl-no-revoke -ix http://localhost:8000 https://jsonplaceholder.typicode.com/posts
+curl -ikx http://localhost:8000 https://jsonplaceholder.typicode.com/posts
 ```
 
 You can also use an API client like [Postman](https://www.postman.com/product/api-client/) to send a GET request to `https://jsonplaceholder.typicode.com/posts`.


### PR DESCRIPTION
On Windows 10, I ran `curl -ix http://localhost:8000 https://jsonplaceholder.typicode.com/posts` as instructed by the documentation.

It produced:

```
HTTP/1.1 200 Connection Established
Content-Length: 0

curl: (35) schannel: next InitializeSecurityContext failed: CRYPT_E_NO_REVOCATION_CHECK (0x80092012) - The revocation function was unable to check revocation for the certificate.
```

Adding `--ssl-no-revoke` bypasses this error with the Dev Proxy self-signed certificate.